### PR TITLE
haproxy dep name changed

### DIFF
--- a/.yoda
+++ b/.yoda
@@ -3,9 +3,10 @@ docker-http:
  pull: true
  p: 2375:2375
  v: /var/run/docker.sock:/var/run/docker.sock
+ remove: true
 automagicproxy:
  image: kcmerrill/automagicproxy
- pull: dockerfile/haproxy
+ pull: haproxy
  build: .
  remove: true
  p: 80:80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Build the haproxy container, add php, run a custom script to make it automagical
-FROM dockerfile/haproxy
+FROM haproxy
 MAINTAINER kc merrill <kcmerrill@gmail.com>
 
 RUN apt-get -y update


### PR DESCRIPTION
`dockerfile/haproxy` was renamed to just `haproxy`
The docker image will need to be rebuilt and pushed. Also the .yoda files being shared will need to be updated to match the new dep name as well.
