### PR TITLE
Add /etc/services file into container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get -y update
 RUN apt-get -y install curl iproute2
 
 COPY . /automagicproxy
+COPY /etc/services /etc/services
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
No idea why this isn't there by default, but this is what maps ports to names.
